### PR TITLE
Add ZH-TR to interwiki

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -15,6 +15,7 @@ export const titlesByLang: {[lang: string]: string} = {
   ua: 'Іншими мовами',
   pt_br: 'Em outros idiomas',
   cs: 'V jiných jazycích',
+  zh_tr: '他國語言版本',
 };
 
 interface InterWikiBranch {
@@ -98,5 +99,10 @@ export const sites: {[name: string]: InterWikiBranch} = {
     title: 'Česky',
     name: 'Czech',
     url: 'http://scp-cs.wikidot.com',
+  },
+  'scp-zh-tr': {
+    title: '繁體中文',
+    name: 'Traditional Chinese',
+    url: 'http://scp-zh-tr.wikidot.com',
   },
 };


### PR DESCRIPTION
Hello,

I'm from the Traditional Chinese (ZH-TR) Unofficial Branch. As our branch is growing, more and more of our articles are being translated. Despite still being an unofficial branch, it would be helpful if our branch can be added to interwiki, both for our translators (so they can see if a translation already exists) and translators from those branches (so, for example, Japanese users who are translating an English user can also read our translation as reference). It's especially weird that parts of our canon that is translated to other wikis don't point back.

Please feel free to edit this PR if anything is wrong; I have followed the conventions and checked to make sure no other files need to be edited to compile but I have not tried deploying.

Uni